### PR TITLE
chat-spaceのデータベース設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,20 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
+- has_many : users_groups
 - has_many : groups through: users_groups
 
 ## groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false, unique: true|
+|name|string|null: false, unique: true|
 
 ### Association
+- has_many : messages
+- has_many : users_groups
 - has_many : users through: users_groups
-- has_many :messages
+
 
 ## users_groupsテーブル
 
@@ -49,8 +52,8 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|text|string|null: false|
-|image|string|null: false|
+|text|string||
+|image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,50 @@ Things you may want to cover:
 * Configuration
 
 * Database creation
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false, unique; true|
+|password|string|null: false, unique; true|
+
+### Association
+- has_many :messages
+- has_many :users_groups
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false, foreign_key: true|
+
+### Association
+- has_many :users_groups
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|text|string|null: false|
+|image|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :users
+
 
 * Database initialization
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false, foreign_key: true|
+|groupname|string|null: false|
 
 ### Association
 - has_many :users_groups
+- has_many :messages
 
 ## groups_usersテーブル
 
@@ -41,8 +42,8 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :group
 - belongs_to :user
+- belongs_to :group
 
 ## messagesテーブル
 
@@ -54,7 +55,8 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :users
+- belongs_to :group
+- belongs_to :user
 
 
 * Database initialization

--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ Things you may want to cover:
 |------|----|-------|
 |name|string|null: false|
 |email|string|null: false, unique; true|
-|password|string|null: false, unique; true|
+|password|string|null: false, unique: true|
 
 ### Association
 - has_many :messages
-- has_many :users_groups
+- has_many : groups through: users_groups
 
 ## groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|group_name|string|null: false, unique: true|
 
 ### Association
-- has_many :users_groups
+- has_many : users through: users_groups
 - has_many :messages
 
-## groups_usersテーブル
+## users_groupsテーブル
 
 |Column|Type|Options|
 |------|----|-------|


### PR DESCRIPTION
# What
chat-spaceを実装していくにあたって、データベースのテーブルとその関係を READMEに記述しました。
create table ver3を確認してください。

テーブルは4つあります。(users, groups, messages, groups_users)
すべてのカラムにNOT NUL制約を付けています。
・usersテーブルのカラムは3つ(name, email, password)
    emailとpasswordには、同じ内容が保存さないよう一意性制約を付けています。
・groupsテーブルのカラムは1つ(groupname)
   group_nameには、同じ内容が保存さないよう一意性制約を付けています。
・messagesテーブルのカラムは4つ(text, image, user_id, group_id)
・users_groupsテーブルのカラムは2つ(user_id, group_id)
usersテーブルとgroupsテーブルの関係が、多対多になるため、中間テーブルとしてusers_groupsテーブルを作成しました。


# why
アプリケーションを作成するにあたり、データの管理は必須で、正しくエンティティ、属性を設定しなければ今後実装を進めていく過程で不都合が起こるため。
今回は初めてのデータベース設計ということで、データベースの作成前に洗い出しがきちんとできているかを確認するためREADMEに記述しています。


