### PR TITLE
create automatic-updating

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,9 +1,8 @@
 $(function(){ 
-  function buildHTML(message){
-   if ( message.image ) {
-
-     var html =
-      `<div class="message-group">
+  var buildHTML = function(message) {
+    if (message.content && message.image) {
+      var html = 
+      `<div class="message-group" data-message-id=${message.id}>
         <div class="message-group__text-items">
           <div class="message-group__text-items__name">
             ${message.user_name}
@@ -16,13 +15,12 @@ $(function(){
           <p class="lower-message__content">
             ${message.content}
           </p>
-          
+          <img src=${message.image} >
         </div>
       </div>`
-     return html;
-   } else {
-     var html =
-      `<div class="message-group">
+    } else if (message.content) {
+      var html =
+      `<div class="message-group" data-message-id=${message.id}>
         <div class="message-group__text-items">
           <div class="message-group__text-items__name">
             ${message.user_name}
@@ -35,17 +33,32 @@ $(function(){
           <p class="lower-message__content">
             ${message.content}
           </p>
-          <img src=${message.image.url} >
+        </div>
+    </div>`
+    } else if (message.image) {
+      var html = 
+      `<div class="message-group" data-message-id=${message.id}>
+        <div class="message-group__text-items">
+          <div class="message-group__text-items__name">
+            ${message.user_name}
+          </div>
+          <div class="message-group__text-items__date">
+            ${message.created_at}
+          </div>
+        </div>
+        <div class="message-group__text-box">
+        <img src=${message.image}>
         </div>
       </div>`
-     return html;
-   };
- }
+    };
+    return html;
+    
+  };
+  
 $('#new_message').on('submit', function(e){
   e.preventDefault();
   var formData = new FormData(this);
   var url = $(this).attr('action')
-  console.log(url);
   $.ajax({
     url: url,
     type: "POST",
@@ -65,4 +78,32 @@ $('#new_message').on('submit', function(e){
       alert("メッセージ送信に失敗しました");
   });
 })
+
+var reloadMessages = function() {
+  var last_message_id = $('.message-group:last').data("message-id");
+  $.ajax({
+    url: "api/messages",
+    type: 'get',
+    dataType: 'json',
+    data: {id: last_message_id}
+  })
+  .done(function(messages, group) {
+    if (messages.length !== 0) {
+      var insertHTML = '';
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.chat-main__message-list').append(insertHTML);
+      $('.chat-main__message-list').animate({ scrollTop: $('.chat-main__message-list')[0].scrollHeight});
+    }
+    
+  })
+  .fail(function() {
+    alert('error');
+  });
+  
+};
+if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  setInterval(reloadMessages, 7000);
+}
 });

--- a/app/assets/stylesheets/_side_bar.scss
+++ b/app/assets/stylesheets/_side_bar.scss
@@ -29,6 +29,7 @@
     }
   }
   &__group-list {
+    overflow: scroll;
     height: calc(100vh - 100px);
     background-color: #2f3e51;
     padding: 0 20px 0 20px;

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,6 @@ class UsersController < ApplicationController
     end
   end
 
-
   def edit
   end
 
@@ -19,9 +18,6 @@ class UsersController < ApplicationController
       render :edit
     end
   end
-
-
-
 
 
 

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message-group
+.message-group.message{data: {message: {id: message.id}}}
   .message-group__text-items
     .message-group__text-items__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
 json.user_name @message.user.name
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
-json.image @message.image
+json.image @message.image.url
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   devise_for :users
-  root "groups#index"
-  resources :users, only: [:index, :edit, :update, :destroy]
+  root 'groups#index'
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
チャットグループの内容が自動更新されるように設定

１、7秒ごとに自動更新される
２、更新されるときに、一番したのメッセージの要素番号を取得し、データベースの中にあるメッセージの要素番号と比較する（カスタムデータ属性によって要素番号をつけている）
４、新しい場合は更新され、自動的に一番下までスクロールされる。
５、すでに更新されている場合は、何も変わらない。

# Why

リロードしなければ更新されないとユーザーに取って不便であり、会話の齟齬が生じる
自動的にスクロールされることで更新されていることがすぐにわかる。


更新されている様子
https://i.gyazo.com/ac4709bbd01ef553aebe3550aad5c187.mp4

